### PR TITLE
Remove git extension from url of packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ mkdir -p ~/.vim/pack/mypackage/start/
 cd ~/.vim/pack/mypackage/start/
 
 declare -a packages=(
-	'git@github.com:EdenEast/nightfox.nvim.git'
+	'git@github.com:EdenEast/nightfox.nvim'
 	'git@github.com:PProvost/vim-ps1'
 	'git@github.com:Shougo/dein.vim'
 	'git@github.com:Shougo/deoplete.nvim'
@@ -18,9 +18,9 @@ declare -a packages=(
 	'git@github.com:Yggdroot/indentLine'
 	'git@github.com:airblade/vim-gitgutter'
 	'git@github.com:ctrlpvim/ctrlp.vim'
-	'git@github.com:dracula/vim.git'
+	'git@github.com:dracula/vim'
 	'git@github.com:flazz/vim-colorschemes'
-	'git@github.com:github/copilot.vim.git'
+	'git@github.com:github/copilot.vim'
 	'git@github.com:itchyny/lightline.vim'
 	'git@github.com:jacoborus/tender.vim'
 	'git@github.com:jpalardy/vim-slime'
@@ -28,7 +28,7 @@ declare -a packages=(
 	'git@github.com:nathanaelkane/vim-indent-guides'
 	'git@github.com:nelstrom/vim-visual-star-search'
 	'git@github.com:rickhowe/diffchar.vim'
-	'git@github.com:sainnhe/edge.git'
+	'git@github.com:sainnhe/edge'
 	'git@github.com:scrooloose/nerdtree'
 	'git@github.com:scrooloose/syntastic'
 	'git@github.com:sudar/vim-arduino-syntax'


### PR DESCRIPTION
Remove git extension from url of packages to compare with existing directories.