### PR TITLE
Fix byobu task to handle single file copy

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -102,7 +102,7 @@ def yazi(c: Context) -> None:
 def byobu(c: Context) -> None:
     """Set up byobu."""
     c.run("mkdir -p ~/.byobu")
-    c.run("cp -r byobu/.byobu/* ~/.byobu/")
+    c.run("cp byobu/.byobu/.tmux.conf ~/.byobu/")
 
 
 @task(default=True)


### PR DESCRIPTION
## Summary
- Fixed the byobu invoke task that was failing with "cp: byobu/.byobu/*: No such file or directory"
- Changed from wildcard pattern to explicitly copy .tmux.conf file

## Test plan
- [x] Run `uv run invoke byobu` to verify it works without errors
- [x] Confirm .tmux.conf is copied to ~/.byobu/

🤖 Generated with [Claude Code](https://claude.ai/code)