### PR TITLE
feat: add opencode to nix develop environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             nodejs_22
             curl
             alejandra
+            opencode
           ];
 
           shellHook = ''


### PR DESCRIPTION
## Summary

Add `opencode` to the default `devShells` `buildInputs` in `flake.nix` so that `opencode` is available inside `nix develop`.

## Changes

- `flake.nix`: add `opencode` (from nixpkgs unstable) to `devShells.default.buildInputs`.

## Rationale

`opencode` is already packaged in nixpkgs unstable (`pkgs.opencode`), so no new flake input or overlay is needed. A single one-line addition to the dev shell is the minimal change required to make `opencode` available in the development environment.

## Verification

- `nix eval nixpkgs#opencode.meta.description` -> `"AI coding agent built for the terminal"`
- `nix flake check --no-build` -> `all checks passed!`

After this PR, running `nix develop` will drop into a shell where the `opencode` binary is on `PATH`.