### PR TITLE
fix: make flake portable across platforms and CWDs

### DIFF
--- a/apps/default.nix
+++ b/apps/default.nix
@@ -1,10 +1,13 @@
-{pkgs}: let
+{
+  pkgs,
+  self,
+}: let
   host = "TetsuonoMacBook-Pro";
 
   homeManagerSwitch = pkgs.writeShellApplication {
     name = "home-manager-switch";
     text = ''
-      nix run nixpkgs#home-manager -- switch --flake .#${host}
+      nix run nixpkgs#home-manager -- switch --flake "${self}#${host}"
     '';
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           text = ''
             echo "Setting up dotfiles..."
 
-            nix run nixpkgs#home-manager -- switch --flake .#TetsuonoMacBook-Pro
+            nix run nixpkgs#home-manager -- switch --flake "${self}#TetsuonoMacBook-Pro"
 
             echo "Dotfiles setup complete!"
             echo "Run 'nix flake show' to see available apps"
@@ -55,7 +55,7 @@
         packages.default = setupScript;
 
         apps =
-          (import ./apps {inherit pkgs;})
+          (import ./apps {inherit pkgs self;})
           // {
             setup = {
               type = "app";
@@ -70,7 +70,7 @@
     // {
       homeConfigurations = {
         "TetsuonoMacBook-Pro" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages."aarch64-darwin";
+          pkgs = nixpkgs.legacyPackages."${builtins.currentSystem}";
           extraSpecialArgs = {
             profile = import ./hosts/TetsuonoMacBook-Pro/profile.nix;
           };

--- a/hosts/TetsuonoMacBook-Pro/profile.nix
+++ b/hosts/TetsuonoMacBook-Pro/profile.nix
@@ -1,6 +1,14 @@
-{
-  username = "tetsuokoyama";
-  homeDirectory = "/Users/tetsuokoyama";
+let
+  isDarwin = builtins.match ".*-darwin" builtins.currentSystem != null;
+in {
+  username =
+    if isDarwin
+    then "tetsuokoyama"
+    else "tetsuo-koyama";
+  homeDirectory =
+    if isDarwin
+    then "/Users/tetsuokoyama"
+    else "/home/tetsuo-koyama";
   gitName = "Tetsuo Koyama";
   gitEmail = "tkoyama010@gmail.com";
 }


### PR DESCRIPTION
## Problem

`nix run github:tkoyama010/dotfiles` fails with:

```
path '/home/tetsuo-koyama' does not contain a 'flake.nix', searching up
error: could not find a flake.nix file
```

Two root causes:

1. **`--flake .` resolves to CWD, not the flake source.** The setupScript and `home-manager` app both use `--flake .#TetsuonoMacBook-Pro`. When run via `nix run github:...`, `.` is the caller's working directory — not the flake source. Fix: use `""` (the flake's own store path).

2. **Hardcoded `aarch64-darwin` in homeConfiguration.** `pkgs = nixpkgs.legacyPackages."aarch64-darwin"` prevents evaluation on Linux. Fix: use `builtins.currentSystem`.

3. **Profile has macOS-only paths.** `homeDirectory = "/Users/tetsuokoyama"` fails on Linux. Fix: detect platform via `builtins.currentSystem` and set username/homeDirectory accordingly.

## Changes

- `flake.nix`: `--flake .` → `--flake "${self}"` in setupScript
- `flake.nix`: pass `self` to `apps/default.nix`
- `flake.nix`: `aarch64-darwin` → `builtins.currentSystem`
- `apps/default.nix`: accept `self`, use `"${self}"` in home-manager switch
- `hosts/TetsuonoMacBook-Pro/profile.nix`: platform-aware username and homeDirectory

## Testing

```bash
# From any directory on Linux
nix run github:tkoyama010/dotfiles

# From any directory on macOS
nix run github:tkoyama010/dotfiles
```

Both should now evaluate and apply the home-manager configuration without the `flake.nix not found` error.