### PR TITLE
fix(flake): replace builtins.currentSystem with explicit system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
     home-manager,
     flake-utils,
     ...
-  }:
+  }: let
+    system = "aarch64-darwin";
+  in
     (flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -70,9 +72,10 @@
     // {
       homeConfigurations = {
         "TetsuonoMacBook-Pro" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages."${builtins.currentSystem}";
+          pkgs = nixpkgs.legacyPackages.${system};
           extraSpecialArgs = {
-            profile = import ./hosts/TetsuonoMacBook-Pro/profile.nix;
+            inherit system;
+            profile = import ./hosts/TetsuonoMacBook-Pro/profile.nix {inherit system;};
           };
           modules = [./modules/home-manager];
         };

--- a/hosts/TetsuonoMacBook-Pro/profile.nix
+++ b/hosts/TetsuonoMacBook-Pro/profile.nix
@@ -1,5 +1,5 @@
-let
-  isDarwin = builtins.match ".*-darwin" builtins.currentSystem != null;
+{system}: let
+  isDarwin = builtins.match ".*-darwin" system != null;
 in {
   username =
     if isDarwin


### PR DESCRIPTION
## Problem

`nix run github:tkoyama010/dotfiles` fails:

```
error: attribute 'currentSystem' missing
       at flake.nix:73:44:
         73|           pkgs = nixpkgs.legacyPackages."${builtins.currentSystem}";
```

## Root cause

`builtins.currentSystem` is unavailable in pure flake evaluation. Used in two places:
- `flake.nix` — to select `pkgs` for `homeConfigurations`
- `hosts/TetsuonoMacBook-Pro/profile.nix` — to detect darwin vs linux

## Fix

Bake explicit `system = "aarch64-darwin"` into the flake and pass it through `extraSpecialArgs` to `profile.nix` (now a function of `{system}`).

## Verification

```
nix flake check --no-build   # all checks passed
```

Skipped: multi-arch support (x86_64-darwin). Add when running on Intel mac.
