### PR TITLE
fix(flake): generate homeConfigurations per system for portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Install directly from GitHub repository:
 nix run github:tkoyama010/dotfiles
 ```
 
-This applies the home-manager configuration for `TetsuonoMacBook-Pro`, which deploys all tracked config files (vimrc, starship, opencode, Claude status line, Copilot, byobu, aider, git) via Nix-managed symlinks. If existing real files conflict, home-manager will report them — run `nix run .#opencode` first to back them up and migrate.
+This applies the home-manager configuration for the current system (e.g. `TetsuonoMacBook-Pro-aarch64-darwin` on macOS, `TetsuonoMacBook-Pro-x86_64-linux` on Linux), which deploys all tracked config files (vimrc, starship, opencode, Claude status line, Copilot, byobu, aider, git) via Nix-managed symlinks. If existing real files conflict, home-manager will report them — run `nix run .#opencode` first to back them up and migrate.
 
 ### Using Nix Flakes (Development)
 

--- a/apps/default.nix
+++ b/apps/default.nix
@@ -3,11 +3,12 @@
   self,
 }: let
   host = "TetsuonoMacBook-Pro";
+  configName = "${host}-${pkgs.system}";
 
   homeManagerSwitch = pkgs.writeShellApplication {
     name = "home-manager-switch";
     text = ''
-      nix run nixpkgs#home-manager -- switch --flake "${self}#${host}"
+      nix run nixpkgs#home-manager -- switch --flake "${self}#${configName}"
     '';
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,17 @@
     flake-utils,
     ...
   }: let
-    system = "aarch64-darwin";
+    host = "TetsuonoMacBook-Pro";
+    systems = flake-utils.lib.defaultSystems;
+    mkHomeConfig = system:
+      home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages.${system};
+        extraSpecialArgs = {
+          inherit system;
+          profile = import ./hosts/${host}/profile.nix {inherit system;};
+        };
+        modules = [./modules/home-manager];
+      };
   in
     (flake-utils.lib.eachDefaultSystem (
       system: let
@@ -28,7 +38,7 @@
           text = ''
             echo "Setting up dotfiles..."
 
-            nix run nixpkgs#home-manager -- switch --flake "${self}#TetsuonoMacBook-Pro"
+            nix run nixpkgs#home-manager -- switch --flake "${self}#${host}-${system}"
 
             echo "Dotfiles setup complete!"
             echo "Run 'nix flake show' to see available apps"
@@ -70,15 +80,12 @@
       }
     ))
     // {
-      homeConfigurations = {
-        "TetsuonoMacBook-Pro" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages.${system};
-          extraSpecialArgs = {
-            inherit system;
-            profile = import ./hosts/TetsuonoMacBook-Pro/profile.nix {inherit system;};
-          };
-          modules = [./modules/home-manager];
-        };
-      };
+      homeConfigurations =
+        builtins.listToAttrs
+        (map (system: {
+            name = "${host}-${system}";
+            value = mkHomeConfig system;
+          })
+          systems);
     };
 }


### PR DESCRIPTION
## Problem

`nix run github:tkoyama010/dotfiles` on a non-darwin host fails:

```
error: Cannot build '...-home-manager-agents.drv'.
       Required system: 'aarch64-darwin' with features {}
       Current system: 'x86_64-linux' ...
```

## Root cause

`flake.nix` hardcoded `system = "aarch64-darwin"` and the default `setup` app ran `home-manager switch --flake ${self}#TetsuonoMacBook-Pro`, the only homeConfiguration — a darwin-only derivation. PR #148 intended portability; #149 re-broke it for pure-eval by pinning darwin.

## Fix

Generate `homeConfigurations` for every `flake-utils.lib.defaultSystems`, keyed `${host}-${system}` (e.g. `TetsuonoMacBook-Pro-x86_64-linux`). The `setup`/`default` and `home-manager` apps now reference the config matching the current system, so `nix run .` builds the native home-manager generation on each platform.

`hosts/TetsuonoMacBook-Pro/profile.nix` already branches username/homeDirectory by darwin vs linux, and the home-manager modules are system-agnostic.

## Verification

- `nix eval .#homeConfigurations --apply 'builtins.attrNames'` lists all four systems.
- `nix build .#homeConfigurations.TetsuonoMacBook-Pro-x86_64-linux.activationPackage --dry-run` no longer errors with a system mismatch.
- Built `apps.x86_64-linux.default` and `apps.x86_64-linux.home-manager`; both scripts reference `...#TetsuonoMacBook-Pro-x86_64-linux`.
- Formatted with `alejandra` (repo formatter).