### PR TITLE
fix(flake): add --refresh to nix run commands to avoid stale cache

### DIFF
--- a/apps/default.nix
+++ b/apps/default.nix
@@ -9,7 +9,7 @@
     name = "home-manager-switch";
     text = ''
       export NIX_CONFIG="extra-experimental-features = nix-command flakes"
-      nix run nixpkgs#home-manager -- switch -b backup --flake "${self}#${configName}"
+      nix run --refresh nixpkgs#home-manager -- switch -b backup --flake "${self}#${configName}"
     '';
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
             echo "Setting up dotfiles..."
 
             export NIX_CONFIG="extra-experimental-features = nix-command flakes"
-            nix run nixpkgs#home-manager -- switch -b backup --flake "${self}#${host}-${system}"
+            nix run --refresh nixpkgs#home-manager -- switch -b backup --flake "${self}#${host}-${system}"
 
             echo "Dotfiles setup complete!"
             echo "Run 'nix flake show' to see available apps"


### PR DESCRIPTION
## Summary
- Add `--refresh` to `nix run` in both `flake.nix` setup script and `apps/default.nix` home-manager-switch app
- Forces nix to re-fetch latest flake revision instead of using stale cached version, preventing cross-platform build failures from outdated configs