### PR TITLE
feat: add python3 to nix devShell and home-manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
             gh
             direnv
             uv
+            python3
             nodejs_22
             curl
             alejandra

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -9,6 +9,7 @@
     ./opencode
     ./git
     ./home
+    ./python
     ./shell
     ./starship
   ];

--- a/modules/home-manager/python/default.nix
+++ b/modules/home-manager/python/default.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  home.packages = [
+    pkgs.python3
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `python3` to `flake.nix` `devShells.default` buildInputs (available in `nix develop`)
- Add new `modules/home-manager/python` module installing `python3` via `home.packages` (available persistently after `home-manager switch`)
- Register the new module in `modules/home-manager/default.nix`

`nix flake check --no-build` passes.