### PR TITLE
feat(skills): add transifex-translate skill for batch translation via browser API

### DIFF
--- a/.agents/skills/transifex-translate/SKILL.md
+++ b/.agents/skills/transifex-translate/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: transifex-translate
+description: |
+  Batch-translate untranslated strings in a Transifex project using the
+  browser-based internal editor API. Discovers all resources with untranslated
+  strings, fetches source text via the Transifex editor AJAX API, and saves
+  translations in bulk — no Transifex CLI or public API token required.
+  Use when user says "translate transifex", "finish transifex translation",
+  "batch translate transifex", or references a Transifex translate URL.
+---
+
+# Transifex Batch Translation
+
+Translate untranslated strings in a Transifex project via the browser editor's
+internal AJAX API. Requires an active browser session logged into Transifex
+(no API token needed — uses session cookies + CSRF).
+
+## Prerequisites
+
+1. **Browser session**: User must be logged into Transifex in the Playwright
+   browser. Navigate to the project translate page first:
+   `https://app.transifex.com/<org>/<project>/translate/#<lang>?q=translated%3Ano`
+2. **TX_TOKEN** (optional): If set in env, can be used for the public API as a
+   fallback. The primary path uses the browser session.
+3. **Playwright browser tools**: All API calls go through `page.evaluate()`
+   with `fetch()` from the logged-in browser context.
+
+## API Endpoints (Internal Editor AJAX)
+
+All endpoints are relative to `https://app.transifex.com`:
+
+| Purpose                      | Method | Path                                                               |
+| ---------------------------- | ------ | ------------------------------------------------------------------ |
+| Project resource stats       | GET    | `/_/editor/ajax/<org>/<project>/project_lang_stats/<lang>/`        |
+| Untranslated string IDs      | POST   | `/_/editor/ajax/<org>/<project>/string/<resource>/ja/ids/`         |
+| String details (source text) | POST   | `/_/editor/ajax/<org>/<project>/string/<resource>/<lang>/segment/` |
+| Save translation             | POST   | `/_/editor/ajax/<org>/<project>/string_detail/<lang>/<string_id>/` |
+
+## Workflow
+
+### 1. Discover resources with untranslated strings
+
+```javascript
+// Inside page.evaluate()
+const csrf = document.cookie.match(/csrftoken=([^;]+)/)[1];
+const resp = await fetch(
+  "/_/editor/ajax/<org>/<project>/project_lang_stats/<lang>/",
+  {
+    headers: {
+      Accept: "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+    },
+  },
+);
+const data = await resp.json();
+const untranslated = data.filter((r) => r.untranslated > 0);
+```
+
+### 2. Fetch untranslated strings for a resource
+
+```javascript
+// Get IDs
+const idsResp = await fetch(
+  `/_/editor/ajax/<org>/<project>/string/<resource>/<lang>/ids/`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": csrf,
+      "X-Requested-With": "XMLHttpRequest",
+    },
+    body: JSON.stringify({ escape: false, translated: "no", s: "default:asc" }),
+  },
+);
+const ids = await idsResp.json();
+
+// Get source text
+const segResp = await fetch(
+  `/_/editor/ajax/<org>/<project>/string/<resource>/<lang>/segment/`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": csrf,
+      "X-Requested-With": "XMLHttpRequest",
+    },
+    body: JSON.stringify({
+      ids: ids,
+      escape: "no",
+      query: "translated=no&s=default:asc",
+    }),
+  },
+);
+const strings = await segResp.json();
+// Returns: [{ id, source, translation, resource_slug, ... }]
+```
+
+### 3. Save a translation
+
+```javascript
+const body = {
+  translations: { 5: { string: translationText } },
+  raw_mode_enabled: false,
+  previous_translations: { 5: { tr_hash: "d41d8cd98f00b204e9800998ecf8427e" } },
+  suggestions: [],
+};
+
+const resp = await fetch(
+  `/_/editor/ajax/<org>/<project>/string_detail/<lang>/<stringId>/`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": csrf,
+      "X-Requested-With": "XMLHttpRequest",
+    },
+    body: "data=" + encodeURIComponent(JSON.stringify(body)),
+  },
+);
+// Status 200 = success
+```
+
+### 4. Batch processing strategy
+
+- Process resources **smallest untranslated count first** to make fast progress.
+- Fetch strings for 10-20 resources at a time, then translate in batches of ~20
+  saves per `page.evaluate()` call to avoid timeouts.
+- For large resources (>100 strings), split save calls into multiple batches.
+- Keep technical tokens unchanged: `:ref:`, `:fa:`, `:doc:`, `code`, `**bold**`,
+  file paths, URLs, tag metadata lines starting with `🏷 Tags:`.
+
+### 5. Translation conventions
+
+- Preserve all RST/Sphinx markup: `:ref:...`, `:doc:...`, `:fa:...`, `:term:...`
+- Preserve code blocks: ` `code` `, `:meth:~...`
+- Preserve URLs and download links: `:download:`...``
+- Tag metadata lines (`🏷 Tags: ...`) are left as-is (machine-generated)
+- Use full-width punctuation for Japanese: `．` (period), `，` (comma)
+- Translate descriptive prose; keep technical terms transliterated or as-is
+
+## Helper Script
+
+A reusable TypeScript module is provided in
+`scripts/batch-translate.ts` — inject it via `page.evaluate()` to fetch,
+translate, and save strings for a list of resources in one call.
+Includes typed interfaces for all API responses and the `window.tx` API.
+
+## Constraints
+
+- Browser must be on a Transifex page for cookies/CSRF to be available.
+- CSRF token is read from `csrftoken` cookie; refresh if session expires.
+- The `tr_hash` for untranslated strings is always
+  `d41d8cd98f00b204e9800998ecf8427e` (MD5 of empty string).
+- Rate limiting: keep batches under ~30 saves per `evaluate()` call to avoid
+  Playwright MCP timeouts (120s default).
+- For very large projects (>2000 strings), process incrementally across
+  multiple sessions — don't attempt all at once.

--- a/.agents/skills/transifex-translate/scripts/batch-translate.ts
+++ b/.agents/skills/transifex-translate/scripts/batch-translate.ts
@@ -1,0 +1,286 @@
+/**
+ * Transifex Batch Translation Helper (TypeScript)
+ *
+ * Inject this script via page.evaluate() in a Playwright browser session
+ * that is logged into Transifex. It provides reusable functions for:
+ *   - Listing untranslated resources
+ *   - Fetching untranslated source strings for a resource
+ *   - Saving translations in bulk
+ *
+ * Usage pattern:
+ *   1. Navigate to the project translate page first.
+ *   2. Call window.tx.listUntranslated() to get resources.
+ *   3. Call window.tx.fetchStrings(slugs) to get source strings.
+ *   4. Build translations array, call window.tx.saveBatch(translations).
+ */
+
+/** A resource with untranslated strings. */
+interface UntranslatedResource {
+  slug: string;
+  untranslated: number;
+}
+
+/** A source string fetched from Transifex. */
+interface SourceString {
+  id: number;
+  source: string;
+  resource: string;
+}
+
+/** A translation to save: { id, t } pair. */
+interface Translation {
+  id: number;
+  t: string;
+}
+
+/** Result of a batch save operation. */
+interface SaveResult {
+  saved: number;
+  ok: boolean;
+  errors: number;
+}
+
+/** The Transifex API response for project language stats. */
+interface ResourceStats {
+  resource__slug: string;
+  resource__last_update: string;
+  translated: number;
+  untranslated: number;
+  review_steps: Record<string, number>;
+}
+
+/** The Transifex API response for string segment details. */
+interface StringSegment {
+  id: number;
+  source: string;
+  translation: string;
+  supports_raw_mode: boolean;
+  resource_slug: string;
+  errors: unknown[];
+  warnings: unknown[];
+  tags: unknown[];
+  wordcount: number;
+  completed_review_steps: number;
+  i18n_type: string;
+  tqi: number | null;
+  tqi_uuid: string | null;
+  exclusivity_status: Record<string, unknown>;
+  description: string;
+}
+
+/** The save translation request body. */
+interface SaveRequestBody {
+  translations: { "5": { string: string } };
+  raw_mode_enabled: boolean;
+  previous_translations: { "5": { tr_hash: string } };
+  suggestions: unknown[];
+}
+
+/** The Transifex helper API exposed on `window.tx`. */
+interface TransifexAPI {
+  getCSRF: () => string;
+  listUntranslated: (
+    org: string,
+    project: string,
+    lang: string,
+  ) => Promise<UntranslatedResource[]>;
+  fetchStrings: (
+    org: string,
+    project: string,
+    lang: string,
+    resourceSlugs: string[],
+  ) => Promise<SourceString[]>;
+  saveBatch: (
+    org: string,
+    project: string,
+    lang: string,
+    translations: Translation[],
+  ) => Promise<SaveResult>;
+}
+
+declare global {
+  interface Window {
+    tx: TransifexAPI;
+  }
+}
+
+/** MD5 hash of empty string — used for untranslated strings. */
+const EMPTY_TR_HASH = "d41d8cd98f00b204e9800998ecf8427e";
+
+/**
+ * Get CSRF token from cookies.
+ * @throws {Error} if not logged in or not on a Transifex page
+ */
+function getCSRF(): string {
+  const m = document.cookie.match(/csrftoken=([^;]+)/);
+  if (!m) {
+    throw new Error(
+      "No csrftoken cookie — not logged in or not on Transifex page",
+    );
+  }
+  return m[1];
+}
+
+/** Common headers for AJAX requests. */
+function ajaxHeaders(csrf: string, json = false): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "X-Requested-With": "XMLHttpRequest",
+  };
+  if (csrf) headers["X-CSRFToken"] = csrf;
+  if (json) headers["Content-Type"] = "application/json";
+  return headers;
+}
+
+/**
+ * Fetch the list of resources with untranslated strings.
+ * @param org - Organization slug (e.g. "tkoyama010")
+ * @param project - Project slug (e.g. "geovista-doc")
+ * @param lang - Target language code (e.g. "ja")
+ * @returns Resources sorted by untranslated count (smallest first)
+ */
+async function listUntranslated(
+  org: string,
+  project: string,
+  lang: string,
+): Promise<UntranslatedResource[]> {
+  const resp = await fetch(
+    `/_/editor/ajax/${org}/${project}/project_lang_stats/${lang}/`,
+    { headers: ajaxHeaders("") },
+  );
+  if (!resp.ok) {
+    throw new Error(`project_lang_stats failed: ${resp.status}`);
+  }
+  const data: ResourceStats[] = await resp.json();
+  return data
+    .filter((r) => r.untranslated > 0)
+    .map((r) => ({
+      slug: r.resource__slug,
+      untranslated: r.untranslated,
+    }))
+    .sort((a, b) => a.untranslated - b.untranslated);
+}
+
+/**
+ * Fetch untranslated source strings for one or more resources.
+ * @param org - Organization slug
+ * @param project - Project slug
+ * @param lang - Target language code
+ * @param resourceSlugs - Resource slugs to fetch strings from
+ * @returns Array of { id, source, resource } for each untranslated string
+ */
+async function fetchStrings(
+  org: string,
+  project: string,
+  lang: string,
+  resourceSlugs: string[],
+): Promise<SourceString[]> {
+  const csrf = getCSRF();
+  const all: SourceString[] = [];
+
+  for (const slug of resourceSlugs) {
+    try {
+      const idsResp = await fetch(
+        `/_/editor/ajax/${org}/${project}/string/${slug}/${lang}/ids/`,
+        {
+          method: "POST",
+          headers: ajaxHeaders(csrf, true),
+          body: JSON.stringify({
+            escape: false,
+            translated: "no",
+            s: "default:asc",
+          }),
+        },
+      );
+      if (!idsResp.ok) continue;
+      const ids: number[] = await idsResp.json();
+      if (ids.length === 0) continue;
+
+      const segResp = await fetch(
+        `/_/editor/ajax/${org}/${project}/string/${slug}/${lang}/segment/`,
+        {
+          method: "POST",
+          headers: ajaxHeaders(csrf, true),
+          body: JSON.stringify({
+            ids,
+            escape: "no",
+            query: "translated=no&s=default:asc",
+          }),
+        },
+      );
+      if (!segResp.ok) continue;
+      const strings: StringSegment[] = await segResp.json();
+      for (const s of strings) {
+        all.push({ id: s.id, source: s.source, resource: slug });
+      }
+    } catch {
+      // skip resource on error
+    }
+  }
+  return all;
+}
+
+/**
+ * Save a batch of translations.
+ * @param org - Organization slug
+ * @param project - Project slug
+ * @param lang - Target language code
+ * @param translations - Array of { id, t } pairs
+ * @returns Summary: { saved, ok, errors }
+ */
+async function saveBatch(
+  org: string,
+  project: string,
+  lang: string,
+  translations: Translation[],
+): Promise<SaveResult> {
+  const csrf = getCSRF();
+  const results: number[] = [];
+
+  for (const { id, t } of translations) {
+    const body: SaveRequestBody = {
+      translations: { "5": { string: t } },
+      raw_mode_enabled: false,
+      previous_translations: { "5": { tr_hash: EMPTY_TR_HASH } },
+      suggestions: [],
+    };
+    try {
+      const resp = await fetch(
+        `/_/editor/ajax/${org}/${project}/string_detail/${lang}/${id}/`,
+        {
+          method: "POST",
+          headers: ajaxHeaders(csrf, true),
+          body: "data=" + encodeURIComponent(JSON.stringify(body)),
+        },
+      );
+      results.push(resp.status);
+    } catch {
+      results.push(0);
+    }
+  }
+
+  return {
+    saved: results.length,
+    ok: results.every((s) => s === 200),
+    errors: results.filter((s) => s !== 200).length,
+  };
+}
+
+// Export to window for use in page.evaluate()
+if (typeof window !== "undefined") {
+  window.tx = {
+    getCSRF,
+    listUntranslated,
+    fetchStrings,
+    saveBatch,
+  };
+}
+
+export { getCSRF, listUntranslated, fetchStrings, saveBatch };
+export type {
+  UntranslatedResource,
+  SourceString,
+  Translation,
+  SaveResult,
+  TransifexAPI,
+};


### PR DESCRIPTION
## Summary

- Add `transifex-translate` skill that uses the Transifex editor's internal AJAX API for batch translation
- No Transifex CLI or public API token required — works via browser session cookies + CSRF
- Includes `SKILL.md` with API endpoint docs, workflow, and translation conventions
- Includes `scripts/batch-translate.js` reusable helper with `listUntranslated`, `fetchStrings`, and `saveBatch` functions

## Context

Discovered the internal editor AJAX API while batch-translating the `mayavi-doc` and `geovista-doc` Transifex projects. The public `api.transifex.com` had DNS resolution issues in some environments, but the browser-based internal API (`/_/editor/ajax/...`) works reliably through the logged-in session. This skill encapsulates that workflow for reuse.

### Key API endpoints documented

| Purpose | Method | Path |
|---------|--------|------|
| Resource stats | GET | `/_/editor/ajax/<org>/<project>/project_lang_stats/<lang>/` |
| Untranslated IDs | POST | `/_/editor/ajax/<org>/<project>/string/<resource>/<lang>/ids/` |
| String details | POST | `/_/editor/ajax/<org>/<project>/string/<resource>/<lang>/segment/` |
| Save translation | POST | `/_/editor/ajax/<org>/<project>/string_detail/<lang>/<id>/` |