### PR TITLE
feat: add 11 icons to skillicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=nix,vim,py,git,bash,linux,aws,terraform,fastapi,fortran,github,githubactions,latex,md,notion,npm,react,svg,sklearn" alt="My Skills" />
+    <img src="https://skillicons.dev/icons?i=nix,vim,py,git,bash,linux,aws,terraform,fastapi,fortran,github,githubactions,latex,md,notion,npm,react,svg,sklearn,ts" alt="My Skills" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=nix,vim,py,git,bash,linux,aws,terraform" alt="My Skills" />
+    <img src="https://skillicons.dev/icons?i=nix,vim,py,git,bash,linux,aws,terraform,fastapi,fortran,github,githubactions,latex,md,notion,npm,react,svg,sklearn" alt="My Skills" />
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- Append `fastapi,fortran,github,githubactions,latex,md,notion,npm,react,svg,sklearn` to the skillicons.dev icon list in `README.md`
- Icon IDs verified against the official [skillicons.dev icons list](https://github.com/tandpfun/skill-icons#icons-list) (`md` = Markdown, `sklearn` = scikit-learn)
- README-only change; no nix packages added since these are libraries/concepts rather than dotfiles CLI tools