### PR TITLE
feat: add rust and ubuntu to skillicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=nix,vim,py,git,bash,linux,aws,terraform,fastapi,fortran,github,githubactions,latex,md,notion,npm,react,svg,sklearn,ts" alt="My Skills" />
+    <img src="https://skillicons.dev/icons?i=nix,vim,py,git,bash,linux,aws,terraform,fastapi,fortran,github,githubactions,latex,md,notion,npm,react,svg,sklearn,ts,rust,ubuntu" alt="My Skills" />
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- Append `rust,ubuntu` to the skillicons.dev icon list in `README.md`
- Icon IDs verified against the official [skillicons.dev icons list](https://github.com/tandpfun/skill-icons#icons-list)
- README-only change

Note: touches the same line as #160, expect a merge conflict when the first of the two merges.