### PR TITLE
chore: add Notion MCP server

### DIFF
--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -34,6 +34,11 @@
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp@latest"],
       "enabled": true
+    },
+    "notion": {
+      "type": "remote",
+      "url": "https://mcp.notion.com/mcp",
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
## Why

OpenCode currently cannot read or write Notion content directly. Meeting notes, feedback, and other Notion pages have to be copy-pasted into the session by hand, which is error-prone and breaks the flow when a task depends on Notion content (e.g. turning meeting feedback into slides/scripts).

## What changes

Adds the official Notion remote MCP server (`https://mcp.notion.com/mcp`) to `opencode/opencode.jsonc`, following the setup described in the [OpenCode + Notion MCP guide](https://qiita.com/RiTa-23/items/d6286fae190426a8966e).

After pulling this change, run:

```
opencode mcp auth notion
```

to complete the OAuth flow once. OpenCode will then be able to read and update Notion pages via MCP tools automatically.