### PR TITLE
feat: manage markdown-preview.nvim with home-manager

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -9,6 +9,7 @@
     ./opencode
     ./git
     ./home
+    ./neovim
     ./shell
     ./starship
   ];

--- a/modules/home-manager/neovim/default.nix
+++ b/modules/home-manager/neovim/default.nix
@@ -1,0 +1,4 @@
+{pkgs, ...}: {
+  xdg.configFile."nvim/pack/hm/start/markdown-preview-nvim".source =
+    pkgs.vimPlugins.markdown-preview-nvim;
+}


### PR DESCRIPTION
## What

Add `modules/home-manager/neovim` which links `pkgs.vimPlugins.markdown-preview-nvim` into `~/.config/nvim/pack/hm/start/`.

## Why

I wanted [markdown-preview.nvim](https://github.com/iamcco/markdown-preview.nvim) in Neovim to preview markdown in a browser. This repo no longer installs Vim plugins since `tasks.py` was dropped, so the plugin needed a home in the flake instead of another ad-hoc clone.

Using the Neovim package path keeps this independent from the dein setup in the separate `nvim` config repo: nothing else in that config has to change, and `programs.neovim` is not enabled, so home-manager does not take over `init.vim`.

The nixpkgs package ships the built `app/` including `node_modules`, so there is no yarn build on the machine.

## Verification

- `nix eval .#homeConfigurations.TetsuonoMacBook-Pro-aarch64-darwin.config.xdg.configFile."nvim/pack/hm/start/markdown-preview-nvim".source` resolves to the plugin store path
- `nix build nixpkgs#vimPlugins.markdown-preview-nvim` succeeds and the result contains `app/node_modules`
- `alejandra --check` passes on the new file

## Follow-up

After `home-manager switch`, drop the `dein#add("iamcco/markdown-preview.nvim", ...)` line from the `nvim` config repo so the plugin is not loaded twice.