### PR TITLE
fix: bump requires-python to >=3.10 for pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ dependencies = []
 description = "Personal dotfiles configuration"
 name = "dotfiles"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 version = "0.1.0"
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
`uv run` failed with a resolution error: `pre-commit>=4.6.2` requires Python `>=3.10`, but `requires-python` was `>=3.9`.

## Changes
- `pyproject.toml`: `requires-python = ">=3.9"` → `">=3.10"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)