### PR TITLE
fix(profile): run ttyd directly instead of the removed invoke task

### DIFF
--- a/.profile
+++ b/.profile
@@ -30,8 +30,8 @@ fi
 export PATH="$HOME/snap/code/194/.local/share/../bin:$PATH"
 
 # Auto-run ttyd
-if [ -d "$HOME/dotfiles" ]; then
-    if ! pgrep -f "uv run invoke ttyd" > /dev/null; then
-        (cd $HOME/dotfiles && uv run invoke ttyd &)
+if command -v ttyd > /dev/null 2>&1; then
+    if ! pgrep -f "ttyd -i 127.0.0.1 -p 7681" > /dev/null; then
+        ttyd -i 127.0.0.1 -p 7681 -W bash > /dev/null 2>&1 &
     fi
 fi


### PR DESCRIPTION
## Summary
`.profile` auto-started ttyd via `uv run invoke ttyd`, but `tasks.py` was removed when the task runner moved to Nix flake apps (#144). Every login shell hit `Can't find any collection named 'tasks'!` and no terminal started.

## Changes
- `.profile`: call `ttyd -i 127.0.0.1 -p 7681 -W bash` directly — same options as the `ttyd` flake app in `apps/default.nix` — guarded by `command -v ttyd`.
- The `pgrep` guard now matches the real process instead of the old invoke command line.

Calling `ttyd` directly rather than `nix run .#ttyd` keeps login shells fast (no flake evaluation) and avoids the `experimental-features` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)