### PR TITLE
feat: manage nix.conf with home-manager

### DIFF
--- a/modules/home-manager/files/default.nix
+++ b/modules/home-manager/files/default.nix
@@ -3,5 +3,6 @@
   home.file = {
     ".vimrc".source = ../../../vimrc;
     ".profile".source = ../../../.profile;
+    ".config/nix/nix.conf".text = "extra-experimental-features = nix-command flakes\n";
   };
 }


### PR DESCRIPTION
## Summary
`nix run .#<app>` failed with `experimental Nix feature 'nix-command' is disabled` because nothing enabled the flakes/nix-command features. That setting lived outside the repo, so every machine needed the same manual fix.

## Changes
- `modules/home-manager/files/default.nix`: manage `~/.config/nix/nix.conf` with `extra-experimental-features = nix-command flakes`.

`extra-experimental-features` (not `experimental-features`) so the value adds to whatever `/etc/nix/nix.conf` sets instead of replacing it.

## Notes
- This cannot bootstrap itself: applying the config uses `nix run .#home-manager`, which already needs the features enabled. A fresh machine still needs one manual `nix --extra-experimental-features 'nix-command flakes' run .#home-manager` (or a hand-written nix.conf) for the first apply.
- If `~/.config/nix/nix.conf` already exists unmanaged, home-manager refuses to activate — remove it first or apply with `-b backup`.