### PR TITLE
fix(opencode): use openrouter glm-4.6v for vision input

### DIFF
--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -6,9 +6,9 @@
     "./plugins/rtk.ts"
   ],
   "provider": {
-    "opencode": {
+    "openrouter": {
       "models": {
-        "glm-5.2": {
+        "z-ai/glm-4.6v": {
           "attachment": true,
           "modalities": {
             "input": ["text", "image"],


### PR DESCRIPTION
## Motivation

GLM-5.2 is a text-only model. Z.ai's developer documentation lists its input and output modalities as `Text` only, and the open weights release confirms no vision encoder. Despite this, the opencode config declared `glm-5.2` with `attachment: true` and `input: ["text", "image"]`, so opencode believed the model could ingest images and forwarded image blocks to the API. The API rejects them with HTTP 400 `does not support image inputs`, and every image attachment fails.

The OpenCode Zen provider catalog does not carry any GLM vision model (only `glm-5`, `glm-5.1`, `glm-5.2`, all text-only), so staying inside Zen cannot fix this. OpenRouter serves `z-ai/glm-4.6v`, a real multimodal vision model, so the vision-capable entry now points there instead. `glm-5.2` keeps working through Zen with its built-in text-only metadata and no longer carries a false image claim.

## Changes

- `opencode/opencode.jsonc`: replace the `opencode/glm-5.2` multimodal override (text + image) with an `openrouter/z-ai/glm-4.6v` override carrying the same attachment/modalities block.

## Notes

- Requires `OPENROUTER_API_KEY` in the environment for the new provider.
- Apply with `nix run .#home-manager` after merge.