### PR TITLE
feat(opencode): add openrouter-image MCP for vision support

### DIFF
--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -5,19 +5,6 @@
     "caveman-opencode-plugin",
     "./plugins/rtk.ts"
   ],
-  "provider": {
-    "opencode": {
-      "models": {
-        "glm-5.2": {
-          "attachment": true,
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        }
-      }
-    }
-  },
   "mcp": {
     "discord": {
       "type": "local",
@@ -39,6 +26,15 @@
       "type": "remote",
       "url": "https://mcp.notion.com/mcp",
       "enabled": true
+    },
+    "openrouter-image": {
+      "type": "local",
+      "command": ["npx", "-y", "openrouter-image-mcp"],
+      "enabled": true,
+      "environment": {
+        "OPENROUTER_API_KEY": "{env:OPENROUTER_API_KEY}",
+        "OPENROUTER_MODEL": "z-ai/glm-4.6v"
+      }
     }
   }
 }


### PR DESCRIPTION
## Motivation

GLM-5.2 is text-only and cannot process image attachments. #169 tried to fix this by switching the provider to `openrouter` and the model to `z-ai/glm-4.6v`, but #170 reverted it because that changed the main model.

This PR takes a different approach: add a dedicated MCP server (`openrouter-image-mcp`) that delegates image analysis to `z-ai/glm-4.6v` through OpenRouter, leaving the main model untouched.

## Why this does not switch the main model

`OPENROUTER_MODEL` is an environment variable scoped to the MCP server child process. Opencode reads it nowhere. The main model stays `glm-5.2` via the `opencode` provider. The agent calls the MCP tool explicitly when an image needs analyzing (e.g. `What does demo.png describe?`).

## Usage

After merging, run `home-manager switch`, restart opencode, and verify with `/mcp` that `openrouter-image` shows `connected`. Place images in a local directory and reference them by path — pasting images directly into the client does not route through MCP.