### PR TITLE
chore(opencode): remove discord MCP server

### DIFF
--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -19,17 +19,6 @@
     }
   },
   "mcp": {
-    "discord": {
-      "type": "local",
-      "command": ["npx", "-y", "@iqai/mcp-discord"],
-      "enabled": true,
-      "environment": {
-        "DISCORD_TOKEN": "{env:DISCORD_TOKEN}",
-        "SAMPLING_ENABLED": "false",
-        "RESPOND_TO_MENTIONS_ONLY": "false",
-        "BLOCK_DMS": "true"
-      }
-    },
     "playwright": {
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp@latest"],


### PR DESCRIPTION
## Motivation

The discord MCP server persistently fails to connect on every opencode launch with `Connection closed`, adding noise to the `/mcp` output and startup logs. It has no current use case in this dotfiles setup.

Remove it until a concrete need for Discord integration re-emerges.