### PR TITLE
chore(tmux): enable extended-keys

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -4,3 +4,4 @@ bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-pipe-and-cancel "xclip -selection clipboard -i"
 bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "xclip -selection clipboard -i"
 bind ] run-shell "xclip -selection clipboard -o | tmux load-buffer - ; tmux paste-buffer"
+set -g extended-keys on


### PR DESCRIPTION
Enable `set -g extended-keys on` so tmux supports keys beyond the standard set (e.g. F13-F20, modified arrow keys) for more flexible keybindings.

## Changes
- `.tmux.conf`: add `set -g extended-keys on`
