### PR TITLE
feat(pi): add gemini-cli-style startup header

### DIFF
--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -1,6 +1,7 @@
 {...}: {
   home.file = {
     ".pi/agent/extensions/gemini-input.ts".source = ./gemini-input.ts;
+    ".pi/agent/extensions/gemini-header.ts".source = ./gemini-header.ts;
     ".pi/agent/themes/gemini.json".source = ./gemini-theme.json;
   };
 }

--- a/modules/home-manager/pi/gemini-header.ts
+++ b/modules/home-manager/pi/gemini-header.ts
@@ -1,0 +1,55 @@
+/**
+ * Gemini-CLI-style startup header.
+ *
+ * Replaces pi's built-in header with gemini-cli's AppHeader look:
+ *  - spark icon (▝▜▄) in accent color
+ *  - "Gemini CLI vX.X.X" bold + version
+ *  - model line below
+ *
+ * Auto-discovered from ~/.pi/agent/extensions/. Reload with /reload.
+ */
+
+import { type ExtensionAPI, VERSION } from "@earendil-works/pi-coding-agent";
+
+// gemini-cli DEFAULT_ICON (spark), built from half-blocks.
+const ICON = "▝▜▄\n  ▝▜▄\n ▗▟▀ \n▝▀    ";
+
+export default function (pi: ExtensionAPI) {
+	pi.on("session_start", (_event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		ctx.ui.setHeader((_tui, theme) => {
+			let cachedKey = "";
+			let cached: string[] = [];
+
+			return {
+				render(width: number): string[] {
+					const model = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "no model";
+					const key = `${model}|${width}`;
+					if (key === cachedKey) return cached;
+					cachedKey = key;
+
+					const accent = (s: string) => theme.fg("accent", s);
+					const primary = (s: string) => theme.fg("text", s);
+					const secondary = (s: string) => theme.fg("muted", s);
+
+					// Icon (4 lines) side by side with title block.
+					const iconLines = ICON.split("\n");
+					const title = `${primary(theme.bold("Gemini CLI"))} ${secondary(`v${VERSION}`)}`;
+					const sub = `${secondary(model)}`;
+
+					// Place title on row 2 (aligned with icon's 2nd line), sub on row 3.
+					const rows: string[] = ["", "", "", "", ""];
+					rows[1] = `${accent(iconLines[1]!)}    ${title}`;
+					rows[2] = `${accent(iconLines[2]!)}    ${sub}`;
+					rows[0] = `${accent(iconLines[0]!)}`;
+					rows[3] = `${accent(iconLines[3]!)}`;
+					cached = rows;
+					return cached;
+				},
+				invalidate() {
+					cachedKey = "";
+				},
+			};
+		});
+	});
+}


### PR DESCRIPTION
## Summary

Replace pi's built-in header with gemini-cli's `AppHeader` look.

| Before (pi default) | After (gemini-cli style) |
|---------------------|--------------------------|
| pi mascot logo | spark icon (▝▜▄) in accent color |
| "pi" title | bold "Gemini CLI v{version}" |
| keybinding hints | model line below |

## Changes

- **`modules/home-manager/pi/gemini-header.ts`** — new extension using `ctx.ui.setHeader()`
- **`modules/home-manager/pi/default.nix`** — symlink to `~/.pi/agent/extensions/gemini-header.ts`

## How it works

A `session_start` extension calls `ctx.ui.setHeader()` with a custom component that renders:
1. gemini-cli's `DEFAULT_ICON` spark (▝▜▄) in `theme.fg("accent")`
2. bold "Gemini CLI" + muted version
3. muted model line (`provider/model`)

Guarded with `ctx.mode === "tui"` so non-TUI modes are unaffected.

## Verification

- Restart pi (not `/reload` — header needs full restart)
- Startup shows spark icon + "Gemini CLI v0.84.2" + model

## Notes

- The old `opencode.ts` extension was removed from `~/.pi/agent/extensions/` locally since it overrode `setHeader`. It was never part of the merged dotfiles pi module, so no removal needed here.