### PR TITLE
feat(pi): add startup header with official pi.dev logo

### DIFF
--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -1,6 +1,7 @@
 {...}: {
   home.file = {
     ".pi/agent/extensions/gemini-input.ts".source = ./gemini-input.ts;
+    ".pi/agent/extensions/gemini-header.ts".source = ./gemini-header.ts;
     ".pi/agent/themes/gemini.json".source = ./gemini-theme.json;
   };
 }

--- a/modules/home-manager/pi/gemini-header.ts
+++ b/modules/home-manager/pi/gemini-header.ts
@@ -1,0 +1,60 @@
+/**
+ * pi startup header — official pi.dev logo + version + model.
+ *
+ * The logo is rasterized from pi.dev's official SVG (logo-auto.svg):
+ *   - P shape (with hole) + i dot, rendered as half-block art
+ *   - accent color like the website
+ * Title/version/model below in gemini-cli-style layout.
+ *
+ * Auto-discovered from ~/.pi/agent/extensions/. Restart pi to apply.
+ */
+
+import { type ExtensionAPI, VERSION } from "@earendil-works/pi-coding-agent";
+
+// Rasterized from pi.dev/logo-auto.svg (viewBox 0 0 800 800).
+// P shape + i dot, using half-blocks (▀▄█) for 2x vertical resolution.
+const LOGO: string[] = [
+	" ▄▄▄▄▄▄▄▄▄▄▄▄     ",
+	" ████████████     ",
+	" ████▀▀▀▀████     ",
+	" ████    ████     ",
+	" ████    ████     ",
+	" ████████    ████ ",
+	" ████████    ████ ",
+	" ████▀▀▀▀    ████ ",
+	" ████        ████ ",
+	" ▀▀▀▀        ▀▀▀▀ ",
+];
+
+export default function (pi: ExtensionAPI) {
+	pi.on("session_start", (_event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		ctx.ui.setHeader((_tui, theme) => {
+			let cachedKey = "";
+			let cached: string[] = [];
+
+			return {
+				render(_width: number): string[] {
+					const model = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "no model";
+					const key = model;
+					if (key === cachedKey) return cached;
+					cachedKey = key;
+
+					const accent = (s: string) => theme.fg("accent", s);
+					const primary = (s: string) => theme.fg("text", s);
+					const secondary = (s: string) => theme.fg("muted", s);
+
+					const logo = LOGO.map((l) => accent(l));
+					const title = `${primary(theme.bold("pi"))} ${secondary(`v${VERSION}`)}`;
+					const sub = `${secondary(model)}`;
+
+					cached = [...logo, "", `  ${title}`, `  ${sub}`];
+					return cached;
+				},
+				invalidate() {
+					cachedKey = "";
+				},
+			};
+		});
+	});
+}


### PR DESCRIPTION
## Summary

Replace pi's built-in startup header with the official [pi.dev](https://pi.dev) logo, rasterized from the site's `logo-auto.svg` into half-block ASCII art.

```
 ▄▄▄▄▄▄▄▄▄▄▄▄     
 ████████████     
 ████▀▀▀▀████     
 ████    ████     
 ████    ████     
 ████████    ████ 
 ████████    ████ 
 ████▀▀▀▀    ████ 
 ████        ████ 
 ▀▀▀▀        ▀▀▀▀ 

  pi v0.84.2
  opencode/glm-5.2
```

## Changes

- **`modules/home-manager/pi/gemini-header.ts`** — new extension using `ctx.ui.setHeader()`
- **`modules/home-manager/pi/default.nix`** — symlink to `~/.pi/agent/extensions/gemini-header.ts`

## How it works

1. Downloaded `pi.dev/logo-auto.svg` and extracted the two path polygons:
   - **P shape** (with hole): outer boundary + inner hole (even-odd fill)
   - **i dot**: separate square at bottom-right
2. Rasterized using point-in-polygon test at 18×20 grid (10 visual rows via half-blocks)
3. Half-block rendering: `█` (both halves), `▀` (top), `▄` (bottom), ` ` (neither)
4. Displayed in `theme.fg("accent")` color, with bold `pi v{VERSION}` and muted model line below

## Verification

- Restart pi (not `/reload` — header needs full restart)
- Startup shows the official pi logo in accent color + version + model

## Notes

- Guarded with `ctx.mode === "tui"` so non-TUI modes are unaffected
- Logo geometry is baked in as a string array (no runtime SVG parsing needed)