### PR TITLE
feat(tmux): set extended-keys-format to csi-u

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -5,3 +5,4 @@ bind -T copy-mode-vi y send -X copy-pipe-and-cancel "xclip -selection clipboard 
 bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "xclip -selection clipboard -i"
 bind ] run-shell "xclip -selection clipboard -o | tmux load-buffer - ; tmux paste-buffer"
 set -g extended-keys on
+set -g extended-keys-format csi-u


### PR DESCRIPTION
## Summary
- Add `set -g extended-keys-format csi-u` to `.tmux.conf`, complementing the existing `extended-keys on` setting so modified keys are reported in CSI-u format.

## Note
The local `~/.tmux.conf` also had `source-file ~/.tmux.config`, which was intentionally left out: it sources a personal file not tracked in this repo and would error on a clean deploy. Say the word if you want that file + line version-controlled too.