### PR TITLE
feat(pi): manage settings.json with opencode/glm-5.2 and caveman package

### DIFF
--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -1,7 +1,8 @@
 {...}: {
   home.file = {
-    ".pi/agent/extensions/gemini-input.ts".source = ./gemini-input.ts;
-    ".pi/agent/extensions/gemini-header.ts".source = ./gemini-header.ts;
-    ".pi/agent/themes/gemini.json".source = ./gemini-theme.json;
+    ".pi/agent/extensions/tkoyama010-input.ts".source = ./tkoyama010-input.ts;
+    ".pi/agent/extensions/tkoyama010-header.ts".source = ./tkoyama010-header.ts;
+    ".pi/agent/themes/tkoyama010.json".source = ./tkoyama010-theme.json;
+    ".pi/agent/settings.json".source = ./settings.json;
   };
 }

--- a/modules/home-manager/pi/settings.json
+++ b/modules/home-manager/pi/settings.json
@@ -1,0 +1,19 @@
+{
+  "theme": "tkoyama010",
+  "defaultProvider": "opencode",
+  "defaultModel": "glm-5.2",
+  "defaultThinkingLevel": "high",
+  "tuiMode": "regular",
+  "steeringMode": "one-at-a-time",
+  "images": {
+    "blockImages": false
+  },
+  "showHardwareCursor": true,
+  "packages": [
+    "git:github.com/DietrichGebert/ponytail",
+    "git:github.com/JuliusBrussee/caveman"
+  ],
+  "compaction": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary

- Link `~/.pi/agent/settings.json` via home-manager so pi settings are version-controlled with the rest of the dotfiles.
- Pin the default model to `opencode/glm-5.2` with thinking level `high`.
- Add the [caveman](https://github.com/JuliusBrussee/caveman) pi package alongside ponytail for terse-prose control.

## Files

- `modules/home-manager/pi/settings.json`: new — mirrors live `~/.pi/agent/settings.json` (minus local-only `lastChangelogVersion`).
- `modules/home-manager/pi/default.nix`: add `home.file` entry for `settings.json`.

`lastChangelogVersion` is intentionally omitted since it is local changelog state, not configuration.