### PR TITLE
feat(pi): add caveman package for terse-prose control

### DIFF
--- a/modules/home-manager/pi/settings.json
+++ b/modules/home-manager/pi/settings.json
@@ -9,7 +9,10 @@
     "blockImages": false
   },
   "showHardwareCursor": true,
-  "packages": ["git:github.com/DietrichGebert/ponytail"],
+  "packages": [
+    "git:github.com/DietrichGebert/ponytail",
+    "git:github.com/JuliusBrussee/caveman"
+  ],
   "compaction": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary

Add `git:github.com/JuliusBrussee/caveman` to the managed pi `packages` list so the [caveman](https://github.com/JuliusBrussee/caveman) skill is installed automatically.

Caveman provides terse-prose control. It complements ponytail: caveman shrinks what the agent *says*, ponytail shrinks what it *builds*.

## Files

- `modules/home-manager/pi/settings.json`: add `git:github.com/JuliusBrussee/caveman` to `packages`.

Stacked on #184 — rebase onto `main` after #184 merges.