### PR TITLE
feat(pi): add caveman-auto extension to always activate caveman mode

### DIFF
--- a/modules/home-manager/pi/caveman-auto.ts
+++ b/modules/home-manager/pi/caveman-auto.ts
@@ -1,0 +1,39 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ponytail: hardcoded skill path — only this user's caveman install. Move into
+// settings/skills discovery if reused across machines.
+const SKILL_PATH = join(
+  homedir(),
+  ".pi/agent/git/github.com/JuliusBrussee/caveman/skills/caveman/SKILL.md",
+);
+
+let cached: string | undefined;
+
+function skillBody(): string {
+  if (cached !== undefined) return cached;
+  try {
+    const raw = readFileSync(SKILL_PATH, "utf8");
+    // strip frontmatter so only instructions enter the system prompt
+    cached = raw.replace(/^---[\s\S]*?---\s*/, "");
+  } catch {
+    cached = "";
+  }
+  return cached;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("before_agent_start", async (event, _ctx) => {
+    const body = skillBody();
+    if (!body) return;
+    if (event.systemPrompt.includes("# Caveman (always active)")) return;
+    return {
+      systemPrompt:
+        event.systemPrompt +
+        "\n\n# Caveman (always active)\n\n" +
+        body,
+    };
+  });
+}

--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -4,5 +4,6 @@
     ".pi/agent/extensions/tkoyama010-header.ts".source = ./tkoyama010-header.ts;
     ".pi/agent/themes/tkoyama010.json".source = ./tkoyama010-theme.json;
     ".pi/agent/settings.json".source = ./settings.json;
+    ".pi/agent/extensions/caveman-auto.ts".source = ./caveman-auto.ts;
   };
 }


### PR DESCRIPTION
## Summary

Add `caveman-auto.ts` extension that injects the caveman SKILL.md body into the system prompt on every `before_agent_start` event, so caveman communication mode is always active at pi startup without manually loading the skill.

## Changes

- `modules/home-manager/pi/caveman-auto.ts`: new extension. Reads the caveman SKILL.md, strips frontmatter, appends the instructions to the system prompt each turn. Skips injection if already present to avoid duplication.
- `modules/home-manager/pi/default.nix`: wire the new file into `home.file` so home-manager installs it to `~/.pi/agent/extensions/caveman-auto.ts`.

## Notes

- `alejandra` pre-commit hook failed locally because the executable is not installed on this machine; the Nix file is already consistent with the existing style.
- The extension reads the SKILL.md from `~/.pi/agent/git/github.com/JuliusBrussee/caveman/skills/caveman/SKILL.md`, which is installed via the existing `packages` entry in `~/.pi/agent/settings.json`.