### PR TITLE
feat(pi): set deepseek-v4-pro as default model

### DIFF
--- a/modules/home-manager/pi/settings.json
+++ b/modules/home-manager/pi/settings.json
@@ -1,7 +1,7 @@
 {
   "theme": "tkoyama010",
   "defaultProvider": "opencode",
-  "defaultModel": "glm-5.2",
+  "defaultModel": "deepseek-v4-pro",
   "defaultThinkingLevel": "high",
   "tuiMode": "regular",
   "steeringMode": "one-at-a-time",


### PR DESCRIPTION
## Summary

Set `deepseek-v4-pro` as the default model in the pi settings managed by home-manager, replacing `glm-5.2`.

## Changes

- Update `modules/home-manager/pi/settings.json` `defaultModel` from `glm-5.2` to `deepseek-v4-pro`

## Rationale

Switch the default coding agent model to `deepseek-v4-pro` for improved reasoning and coding performance. The live `~/.pi/agent/settings.json` already uses `deepseek-v4-pro`; this commit brings the dotfiles source in sync.