### PR TITLE
feat(pi): add /exit command as alias for /quit

### DIFF
--- a/modules/home-manager/pi/caveman-auto.ts
+++ b/modules/home-manager/pi/caveman-auto.ts
@@ -1,0 +1,39 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ponytail: hardcoded skill path — only this user's caveman install. Move into
+// settings/skills discovery if reused across machines.
+const SKILL_PATH = join(
+  homedir(),
+  ".pi/agent/git/github.com/JuliusBrussee/caveman/skills/caveman/SKILL.md",
+);
+
+let cached: string | undefined;
+
+function skillBody(): string {
+  if (cached !== undefined) return cached;
+  try {
+    const raw = readFileSync(SKILL_PATH, "utf8");
+    // strip frontmatter so only instructions enter the system prompt
+    cached = raw.replace(/^---[\s\S]*?---\s*/, "");
+  } catch {
+    cached = "";
+  }
+  return cached;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("before_agent_start", async (event, _ctx) => {
+    const body = skillBody();
+    if (!body) return;
+    if (event.systemPrompt.includes("# Caveman (always active)")) return;
+    return {
+      systemPrompt:
+        event.systemPrompt +
+        "\n\n# Caveman (always active)\n\n" +
+        body,
+    };
+  });
+}

--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -4,5 +4,6 @@
     ".pi/agent/extensions/tkoyama010-header.ts".source = ./tkoyama010-header.ts;
     ".pi/agent/themes/tkoyama010.json".source = ./tkoyama010-theme.json;
     ".pi/agent/settings.json".source = ./settings.json;
+    ".pi/agent/extensions/caveman-auto.ts".source = ./caveman-auto.ts;
   };
 }

--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -5,5 +5,6 @@
     ".pi/agent/themes/tkoyama010.json".source = ./tkoyama010-theme.json;
     ".pi/agent/settings.json".source = ./settings.json;
     ".pi/agent/extensions/caveman-auto.ts".source = ./caveman-auto.ts;
+    ".pi/agent/extensions/exit-command.ts".source = ./exit-command.ts;
   };
 }

--- a/modules/home-manager/pi/exit-command.ts
+++ b/modules/home-manager/pi/exit-command.ts
@@ -1,0 +1,14 @@
+/**
+ * /exit command — alias for the built-in /quit.
+ * pi ships /quit but not /exit; many CLIs use /exit, so register it for muscle memory.
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("exit", {
+    description: "Exit pi cleanly (alias for /quit)",
+    handler: async (_args, ctx) => {
+      ctx.shutdown();
+    },
+  });
+}


### PR DESCRIPTION
pi ships a built-in `/quit` command but no `/exit`. Many CLIs use `/exit`, so register it as an alias via a small extension that calls `ctx.shutdown()`.

## Changes
- `modules/home-manager/pi/exit-command.ts` — new extension registering `/exit`
- `modules/home-manager/pi/default.nix` — wire the extension into `~/.pi/agent/extensions/`

After `home-manager switch`, `/exit` quits pi cleanly, same as `/quit`.