### PR TITLE
feat(pi): register dotfiles as installable pi package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "tkoyama010-dotfiles",
+  "version": "0.1.0",
+  "description": "pi extensions, theme, and skills from tkoyama010's dotfiles",
+  "keywords": [
+    "pi-package"
+  ],
+  "license": "MIT",
+  "pi": {
+    "extensions": [
+      "modules/home-manager/pi/*.ts"
+    ],
+    "themes": [
+      "modules/home-manager/pi/tkoyama010-theme.json"
+    ],
+    "skills": [
+      ".agents/skills",
+      ".claude/skills"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Add root `package.json` with a `pi` manifest so this repo can be installed as a pi package:

```bash
pi install git:github.com/tkoyama010/dotfiles
```

## What the manifest declares

- **extensions**: `modules/home-manager/pi/*.ts` (tkoyama010-input, tkoyama010-header, caveman-auto)
- **themes**: `modules/home-manager/pi/tkoyama010-theme.json`
- **skills**: `.agents/skills` and `.claude/skills` (SKILL.md-based)

Adds the `pi-package` keyword for gallery discoverability.

## Test plan

- [ ] `pi install git:github.com/tkoyama010/dotfiles` succeeds
- [ ] `pi list` shows `git:github.com/tkoyama010/dotfiles`
- [ ] extensions/theme/skills load after install