### PR TITLE
feat(pi): disable tkoyama010-input extension

### DIFF
--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -1,6 +1,5 @@
 {...}: {
   home.file = {
-    ".pi/agent/extensions/tkoyama010-input.ts".source = ./tkoyama010-input.ts;
     ".pi/agent/extensions/tkoyama010-header.ts".source = ./tkoyama010-header.ts;
     ".pi/agent/themes/tkoyama010.json".source = ./tkoyama010-theme.json;
     ".pi/agent/settings.json".source = ./settings.json;


### PR DESCRIPTION
## Summary

Stop deploying `tkoyama010-input.ts` via home-manager by removing it from `default.nix`. The source file is kept in the repo for potential re-enable later.

## Test plan

- [ ] `home-manager switch` no longer writes `~/.pi/agent/extensions/tkoyama010-input.ts`
- [ ] `pi` startup no longer loads tkoyama010-input extension