### PR TITLE
fix(ttyd): set Nerd Font so icons render in web terminal

### DIFF
--- a/.profile
+++ b/.profile
@@ -32,6 +32,6 @@ export PATH="$HOME/snap/code/194/.local/share/../bin:$PATH"
 # Auto-run ttyd
 if command -v ttyd > /dev/null 2>&1; then
     if ! pgrep -f "ttyd -i 127.0.0.1 -p 7681" > /dev/null; then
-        ttyd -i 127.0.0.1 -p 7681 -W bash > /dev/null 2>&1 &
+        ttyd -i 127.0.0.1 -p 7681 -W -t fontFamily='FiraCode Nerd Font Mono' bash > /dev/null 2>&1 &
     fi
 fi

--- a/apps/default.nix
+++ b/apps/default.nix
@@ -93,7 +93,7 @@
     name = "ttyd-web";
     runtimeInputs = with pkgs; [ttyd bash];
     text = ''
-      ttyd -i 127.0.0.1 -p 7681 -W bash
+      ttyd -i 127.0.0.1 -p 7681 -W -t fontFamily='FiraCode Nerd Font Mono' bash
     '';
   };
 


### PR DESCRIPTION
## Problem

When logging into the ttyd web terminal at http://localhost:7681/, Nerd Font
icons (used by starship and other prompt tools) did not render — they showed
as tofu/missing glyphs.

## Root cause

xterm.js (ttyd's frontend) defaults to a generic `monospace` font family.
Nerd Font glyphs are only available in a Nerd Font, so without an explicit
`fontFamily` the browser falls back to a font that lacks the private-use
icon codepoints.

## Fix

Pass `-t fontFamily='FiraCode Nerd Font Mono'` to ttyd in both launch sites:

- `apps/default.nix` (`ttyd-web` nix app)
- `.profile` (autostart)

`FiraCode Nerd Font Mono` is already installed on this machine, so no new
dependency is needed.

## Notes

- Applies only when the browser runs on the same machine as ttyd (the font
  must be installed locally). Serving to remote clients would require
  embedding the font via a custom `index.html` (`-I`); out of scope here.
