### PR TITLE
feat(shell): set CAVEMAN_DEFAULT_MODE=full

### DIFF
--- a/modules/home-manager/shell/default.nix
+++ b/modules/home-manager/shell/default.nix
@@ -1,5 +1,4 @@
-{ ... }:
-{
+{...}: {
   programs.direnv = {
     enable = true;
     enableZshIntegration = true;
@@ -14,6 +13,7 @@
     };
     sessionVariables = {
       EDITOR = "vim";
+      CAVEMAN_DEFAULT_MODE = "full";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Add `CAVEMAN_DEFAULT_MODE=full` to zsh `sessionVariables` in home-manager config
- Ensures caveman mode auto-activates as `full` on every shell session start
- Persists across machines via dotfiles

## Test plan

- [x] `home-manager switch` succeeds
- [x] `~/.zshenv` contains `export CAVEMAN_DEFAULT_MODE="full"`
- [x] New shell sessions auto-activate caveman full mode