### PR TITLE
chore: gitignore pi local install artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Nix
 # Python cache
 # opencode - exclude generated/local artifacts
+# pi local install artifacts (.pi/settings.json is covered by global home-manager settings)
 *.pyc
 *.swp
 *~
@@ -15,6 +16,7 @@
 .copilot/session-state/
 .direnv
 .emacs.d/history
+.pi/
 .python-version
 .ruff_cache/
 .ssh


### PR DESCRIPTION
## Summary

Project-level `.pi/` ( `settings.json`, `npm/`, `git/` ) is generated by local `pi install -l` runs and is fully redundant with the global `~/.pi/agent/settings.json` managed by home-manager.

This was surfaced while enabling `npm:@pi-kaush/pi-welcome-screen`: a stray project `.pi/settings.json` duplicating the welcome-screen entry had been created by a local `pi install -l` and was cluttering `git status`.

## Changes

- Add `.pi/` to `.gitignore` so local pi install artifacts do not pollute git status.

## Rationale

- Global `~/.pi/agent/settings.json` (home-manager managed, see `modules/home-manager/pi/settings.json`) is the canonical pi config for this machine.
- No project-level pi settings are needed for this repo today.

## Checklist

- [x] `.gitignore` entry added
- [x] pre-commit hooks pass