### PR TITLE
feat(pi): add pi-vision-handoff extension for text-only model vision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Nix
 # Python cache
 # opencode - exclude generated/local artifacts
+# pi local install artifacts (.pi/settings.json is covered by global home-manager settings)
 *.pyc
 *.swp
 *~
@@ -15,6 +16,7 @@
 .copilot/session-state/
 .direnv
 .emacs.d/history
+.pi/
 .python-version
 .ruff_cache/
 .ssh

--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -3,6 +3,7 @@
     ".pi/agent/themes/tkoyama010.json".source = ./tkoyama010-theme.json;
     ".pi/agent/settings.json".source = ./settings.json;
     ".pi/agent/extensions/caveman-auto.ts".source = ./caveman-auto.ts;
+    ".pi/agent/extensions/vision-handoff-aware.ts".source = ./vision-handoff-aware.ts;
     ".pi/agent/extensions/pi-vision-handoff.json".source = ./pi-vision-handoff.json;
     ".pi/agent/models.json".source = ./models.json;
   };

--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -3,5 +3,6 @@
     ".pi/agent/themes/tkoyama010.json".source = ./tkoyama010-theme.json;
     ".pi/agent/settings.json".source = ./settings.json;
     ".pi/agent/extensions/caveman-auto.ts".source = ./caveman-auto.ts;
+    ".pi/agent/extensions/pi-vision-handoff.json".source = ./pi-vision-handoff.json;
   };
 }

--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -4,5 +4,6 @@
     ".pi/agent/settings.json".source = ./settings.json;
     ".pi/agent/extensions/caveman-auto.ts".source = ./caveman-auto.ts;
     ".pi/agent/extensions/pi-vision-handoff.json".source = ./pi-vision-handoff.json;
+    ".pi/agent/models.json".source = ./models.json;
   };
 }

--- a/modules/home-manager/pi/models.json
+++ b/modules/home-manager/pi/models.json
@@ -1,0 +1,17 @@
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        { "id": "qwen2.5vl:3b", "input": ["text", "image"] },
+        { "id": "qwen2.5vl:7b", "input": ["text", "image"] }
+      ]
+    }
+  }
+}

--- a/modules/home-manager/pi/pi-vision-handoff.json
+++ b/modules/home-manager/pi/pi-vision-handoff.json
@@ -1,0 +1,11 @@
+{
+  "enabled": true,
+  "visionModel": "ollama/qwen2.5vl:7b",
+  "autoHandoff": true,
+  "handoffModels": [],
+  "prewarmPastedImages": false,
+  "asyncClipboardHandoff": false,
+  "maxTokens": null,
+  "cacheMax": 50,
+  "maxDescriptionLines": 0
+}

--- a/modules/home-manager/pi/settings.json
+++ b/modules/home-manager/pi/settings.json
@@ -14,7 +14,8 @@
     "git:github.com/JuliusBrussee/caveman",
     "npm:pi-zentui",
     "npm:@josephyoung/pi-exit",
-    "npm:@pi-kaush/pi-welcome-screen"
+    "npm:@pi-kaush/pi-welcome-screen",
+    "npm:pi-vision-handoff"
   ],
   "compaction": {
     "enabled": true

--- a/modules/home-manager/pi/vision-handoff-aware.ts
+++ b/modules/home-manager/pi/vision-handoff-aware.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -7,6 +7,22 @@ import { join } from "node:path";
 // because pi-vision-handoff proxies image input through a vision model.
 // Without this, the read tool's "[Current model does not support images…]"
 // note and the model's own self-knowledge make it reluctant to read images.
+//
+// Off by default. Toggle with /vision-handoff-aware on|off|status.
+
+interface AwareConfig {
+  enabled: boolean;
+}
+
+const CONFIG_PATH = join(
+  homedir(),
+  ".pi/agent/extensions/vision-handoff-aware.json",
+);
+
+const HANDOFF_CONFIG_PATH = join(
+  homedir(),
+  ".pi/agent/extensions/pi-vision-handoff.json",
+);
 
 interface VisionHandoffConfig {
   enabled: boolean;
@@ -15,15 +31,24 @@ interface VisionHandoffConfig {
   handoffModels: string[];
 }
 
-const CONFIG_PATH = join(
-  homedir(),
-  ".pi/agent/extensions/pi-vision-handoff.json",
-);
-
-function readConfig(): VisionHandoffConfig | null {
-  if (!existsSync(CONFIG_PATH)) return null;
+function readAwareConfig(): AwareConfig {
+  if (!existsSync(CONFIG_PATH)) return { enabled: false };
   try {
-    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as Partial<VisionHandoffConfig>;
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as Partial<AwareConfig>;
+    return { enabled: raw.enabled ?? false };
+  } catch {
+    return { enabled: false };
+  }
+}
+
+function writeAwareConfig(cfg: AwareConfig): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n", "utf8");
+}
+
+function readHandoffConfig(): VisionHandoffConfig | null {
+  if (!existsSync(HANDOFF_CONFIG_PATH)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(HANDOFF_CONFIG_PATH, "utf8")) as Partial<VisionHandoffConfig>;
     return {
       enabled: raw.enabled ?? true,
       visionModel: raw.visionModel ?? null,
@@ -54,17 +79,51 @@ const NOTE = `# Image reading (pi-vision-handoff active)
 
 This model lacks native image input, but the pi-vision-handoff extension is enabled: when you call the read tool on an image file, a configured vision model (${"{visionModel}"}) describes it and the description is injected as text in the tool result. You CAN read and act on images via the read tool — do not refuse image-reading requests or claim you cannot see images. The "[Current model does not support images…]" note in tool output is stale and is stripped by the extension.`;
 
+const MARKER = "# Image reading (pi-vision-handoff active)";
+
 export default function (pi: ExtensionAPI) {
+  let aware = readAwareConfig();
+
   pi.on("before_agent_start", async (event, ctx) => {
-    const cfg = readConfig();
+    if (!aware.enabled) return;
+    const cfg = readHandoffConfig();
     if (!cfg || !cfg.enabled || !cfg.visionModel) return;
     if (!isHandoffTarget(ctx.model, cfg)) return;
-    if (event.systemPrompt.includes("# Image reading (pi-vision-handoff active)")) return;
+    if (event.systemPrompt.includes(MARKER)) return;
     return {
       systemPrompt:
         event.systemPrompt +
         "\n\n" +
         NOTE.replace("{visionModel}", cfg.visionModel),
     };
+  });
+
+  pi.registerCommand("vision-handoff-aware", {
+    description: "Toggle the vision-handoff-aware system-prompt note (off by default)",
+    getArgumentCompletions(prefix: string) {
+      const subs = ["on", "off", "status"];
+      const matches = subs.filter((s) => s.startsWith(prefix));
+      return matches.length > 0 ? matches.map((s) => ({ value: s, label: s })) : null;
+    },
+    handler: async (args, ctx) => {
+      const arg = args.trim().toLowerCase();
+      if (arg === "on") {
+        aware = { enabled: true };
+        writeAwareConfig(aware);
+        ctx.ui.notify("vision-handoff-aware: on", "info");
+        return;
+      }
+      if (arg === "off") {
+        aware = { enabled: false };
+        writeAwareConfig(aware);
+        ctx.ui.notify("vision-handoff-aware: off", "info");
+        return;
+      }
+      if (arg === "status" || arg === "") {
+        ctx.ui.notify(`vision-handoff-aware: ${aware.enabled ? "on" : "off"}`, "info");
+        return;
+      }
+      ctx.ui.notify("Usage: /vision-handoff-aware <on|off|status>", "warning");
+    },
   });
 }

--- a/modules/home-manager/pi/vision-handoff-aware.ts
+++ b/modules/home-manager/pi/vision-handoff-aware.ts
@@ -1,0 +1,70 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Tell pi at startup that images are readable even on text-only models,
+// because pi-vision-handoff proxies image input through a vision model.
+// Without this, the read tool's "[Current model does not support images…]"
+// note and the model's own self-knowledge make it reluctant to read images.
+
+interface VisionHandoffConfig {
+  enabled: boolean;
+  visionModel: string | null;
+  autoHandoff: boolean;
+  handoffModels: string[];
+}
+
+const CONFIG_PATH = join(
+  homedir(),
+  ".pi/agent/extensions/pi-vision-handoff.json",
+);
+
+function readConfig(): VisionHandoffConfig | null {
+  if (!existsSync(CONFIG_PATH)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as Partial<VisionHandoffConfig>;
+    return {
+      enabled: raw.enabled ?? true,
+      visionModel: raw.visionModel ?? null,
+      autoHandoff: raw.autoHandoff ?? true,
+      handoffModels: raw.handoffModels ?? [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isVisionModel(model: { input?: ("text" | "image")[] } | undefined): boolean {
+  return Array.isArray(model?.input) && model.input.includes("image");
+}
+
+function isHandoffTarget(
+  model: { provider?: string; id?: string; input?: ("text" | "image")[] } | undefined,
+  cfg: VisionHandoffConfig,
+): boolean {
+  if (!model || !model.provider || !model.id) return false;
+  const ref = `${model.provider}/${model.id}`;
+  if (cfg.handoffModels.includes(ref)) return true;
+  if (cfg.autoHandoff && !isVisionModel(model)) return true;
+  return false;
+}
+
+const NOTE = `# Image reading (pi-vision-handoff active)
+
+This model lacks native image input, but the pi-vision-handoff extension is enabled: when you call the read tool on an image file, a configured vision model (${"{visionModel}"}) describes it and the description is injected as text in the tool result. You CAN read and act on images via the read tool — do not refuse image-reading requests or claim you cannot see images. The "[Current model does not support images…]" note in tool output is stale and is stripped by the extension.`;
+
+export default function (pi: ExtensionAPI) {
+  pi.on("before_agent_start", async (event, ctx) => {
+    const cfg = readConfig();
+    if (!cfg || !cfg.enabled || !cfg.visionModel) return;
+    if (!isHandoffTarget(ctx.model, cfg)) return;
+    if (event.systemPrompt.includes("# Image reading (pi-vision-handoff active)")) return;
+    return {
+      systemPrompt:
+        event.systemPrompt +
+        "\n\n" +
+        NOTE.replace("{visionModel}", cfg.visionModel),
+    };
+  });
+}


### PR DESCRIPTION
## What

Adds the [`pi-vision-handoff`](https://pi.dev/packages/pi-vision-handoff) extension so text-only pi models (e.g. the default `glm-5.2`) can "see" images. A vision model describes each image, and the description text is swapped in for the image block before the request fires — before pi-ai strips image blocks for non-vision models.

## Why

The default model (`glm-5.2`) is text-only. Pasted screenshots, UI mocks, diagrams, and `read`-tool images are otherwise silently dropped or rejected. `pi-vision-handoff` is provider-agnostic and reuses pi's own `completeSimple()`, so any vision model pi knows about can serve as the describer.

## Changes

- `modules/home-manager/pi/settings.json`: register `npm:pi-vision-handoff` in `packages`.
- `modules/home-manager/pi/pi-vision-handoff.json` (new): managed runtime config deployed to `~/.pi/agent/extensions/pi-vision-handoff.json`. Defaults:
  - `visionModel`: `ollama/qwen2.5vl:7b` (local, no API key)
  - `autoHandoff`: `true` (applies to every non-vision model)
  - opt-in features (`prewarmPastedImages`, `asyncClipboardHandoff`) off
- `modules/home-manager/pi/default.nix`: link the new config via `home.file`.

## Prerequisites

- Ollama running locally (`brew services start ollama`) with the model pulled: `ollama pull qwen2.5vl:7b`. For a lighter footprint, swap to `ollama/qwen2.5vl:3b`.
- Run `home-manager switch` after merging to deploy the new settings symlink and config.

## Verify

```
$ pi list | grep vision-handoff
  npm:pi-vision-handoff
```

Then in pi: `/vision-handoff status` confirms the describer is active for the current model.