### PR TITLE
feat(pi): add rtk extension for token savings

### DIFF
--- a/modules/home-manager/home/default.nix
+++ b/modules/home-manager/home/default.nix
@@ -1,4 +1,8 @@
-{profile, pkgs, ...}: {
+{
+  profile,
+  pkgs,
+  ...
+}: {
   home = {
     username = profile.username;
     homeDirectory = profile.homeDirectory;
@@ -6,6 +10,7 @@
     packages = with pkgs; [
       awscli2
       terraform
+      rtk
     ];
   };
 

--- a/modules/home-manager/pi/default.nix
+++ b/modules/home-manager/pi/default.nix
@@ -5,6 +5,7 @@
     ".pi/agent/extensions/caveman-auto.ts".source = ./caveman-auto.ts;
     ".pi/agent/extensions/vision-handoff-aware.ts".source = ./vision-handoff-aware.ts;
     ".pi/agent/extensions/pi-vision-handoff.json".source = ./pi-vision-handoff.json;
+    ".pi/agent/extensions/rtk.ts".source = ./rtk.ts;
     ".pi/agent/models.json".source = ./models.json;
   };
 }

--- a/modules/home-manager/pi/rtk.ts
+++ b/modules/home-manager/pi/rtk.ts
@@ -1,0 +1,80 @@
+// RTK Pi extension — rewrites bash commands to use rtk for token savings.
+// Requires: rtk >= 0.23.0 in PATH.
+//
+// This is a thin delegating extension: all rewrite logic lives in `rtk rewrite`,
+// which is the single source of truth (src/discover/registry.rs).
+// To add or change rewrite rules, edit the Rust registry — not this file.
+//
+// Exit code contract for `rtk rewrite`:
+//   0 + stdout  Rewrite found → mutate command
+//   1           No RTK equivalent → pass through unchanged
+//   3 + stdout  Rewrite (advisory) → mutate command
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent"
+
+const REWRITE_TIMEOUT_MS = 2_000
+const MIN_SUPPORTED_RTK_MINOR = 23
+
+// Parse "X.Y.Z" semver, return [major, minor, patch] or null.
+function parseSemver(raw: string): [number, number, number] | null {
+  const m = raw.trim().match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return null
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)]
+}
+
+// Calls `rtk rewrite`; returns the rewritten command or null (pass through).
+async function rewriteCommand(
+  pi: ExtensionAPI,
+  cmd: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const result = await pi.exec("rtk", ["rewrite", cmd], {
+    timeout: REWRITE_TIMEOUT_MS,
+    signal,
+  })
+  if (result.killed) return null
+  if (result.code !== 0 && result.code !== 3) return null
+  return result.stdout.trim() || null
+}
+
+export default async function (pi: ExtensionAPI) {
+  // Probe rtk version at load time; disables extension if missing or too old.
+  const ver = await pi.exec("rtk", ["--version"], { timeout: REWRITE_TIMEOUT_MS })
+  if (ver.code !== 0) {
+    console.warn("[rtk] rtk binary not found in PATH — extension disabled")
+    return
+  }
+
+  // Warn and bail if rtk predates 0.23.0 (when `rtk rewrite` was introduced).
+  const parsed = parseSemver(ver.stdout.replace(/^rtk\s+/, ""))
+  if (parsed) {
+    const [major, minor] = parsed
+    if (major === 0 && minor < MIN_SUPPORTED_RTK_MINOR) {
+      console.warn(`[rtk] rtk ${ver.stdout.trim()} is too old (need >= 0.23.0) — extension disabled`)
+      return
+    }
+  }
+
+  pi.on("tool_call", async (event, ctx) => {
+    try {
+      if (!isToolCallEventType("bash", event)) return
+
+      const cmd = event.input.command
+      if (typeof cmd !== "string" || cmd.trim() === "") return
+
+      if (cmd.startsWith("rtk ")) return
+      if (process.env.RTK_DISABLED === "1") return
+
+      // Delegate to RTK.
+      const rewritten = await rewriteCommand(pi, cmd, ctx.signal)
+      if (rewritten && rewritten !== cmd) {
+        event.input.command = rewritten
+      }
+    } catch (err) {
+      // Fail open: never block execution on an unexpected error.
+      console.warn("[rtk] unexpected error in tool_call handler; passing through command", err)
+      return
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Install [rtk](https://www.rtk-ai.app/) (a CLI proxy that cuts LLM token consumption on common dev commands) into pi automatically during `home-manager switch`, instead of requiring a manual `rtk init -g --agent pi` run.

## Changes

- **`modules/home-manager/pi/rtk.ts`** — vendored rtk pi extension. It hooks `bash` tool calls and rewrites them through `rtk rewrite` (single source of truth lives in `rtk` itself; this file just delegates). Requires `rtk >= 0.23.0` in PATH; fails open on error.
- **`modules/home-manager/pi/default.nix`** — deploy the extension to `~/.pi/agent/extensions/rtk.ts` via `home.file`. Pi auto-loads `extensions/`, so no `packages` entry or settings change is needed.
- **`modules/home-manager/home/default.nix`** — add the `rtk` binary to home packages via nixpkgs (currently 0.44.2, satisfies the `>= 0.23.0` requirement).

## How it works

On pi startup, the extension probes `rtk --version`. If present and recent enough, every `bash` tool call is passed to `rtk rewrite` and the command is mutated in place to the token-optimized form (e.g. `ls` → `rtk ls`, `git log` → `rtk git log`). If `rtk` is missing or too old, the extension disables itself and commands pass through unchanged.

## Verification

```bash
pi -e ~/.pi/agent/extensions/rtk.ts --no-session
```

Disable at runtime with `RTK_DISABLED=1`. Remove with `rtk init -g --agent pi --uninstall` (or revert this PR).