### PR TITLE
feat(ollama): add ollama service with qwen2.5vl:7b model

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,5 +1,4 @@
-{ ... }:
-{
+{...}: {
   imports = [
     ./aider
     ./byobu
@@ -10,6 +9,7 @@
     ./git
     ./home
     ./neovim
+    ./ollama
     ./pi
     ./shell
     ./starship

--- a/modules/home-manager/ollama/default.nix
+++ b/modules/home-manager/ollama/default.nix
@@ -1,0 +1,8 @@
+{...}: {
+  services.ollama = {
+    enable = true;
+    loadModels = [
+      "qwen2.5vl:7b"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

Adds a home-manager module that enables the `ollama` systemd user service and preloads the `qwen2.5vl:7b` vision model.

## Motivation

`pi-vision-handoff` is configured to proxy image input through `ollama/qwen2.5vl:7b` (see `modules/home-manager/pi/pi-vision-handoff.json`), letting text-only models read images via the `read` tool. That backend only works when an `ollama serve` instance is running locally and the model is pulled. Installing ollama through nix keeps it declarative and reproducible alongside the rest of the dotfiles, instead of relying on a manual `curl | sh` install.

## Changes

- `modules/home-manager/ollama/default.nix`: new module enabling `services.ollama` with `loadModels = [ "qwen2.5vl:7b" ]`.
- `modules/home-manager/default.nix`: import the new module.

## Verification

- `nix flake check` passes for `x86_64-linux`.
- `alejandra` formatting applied.

## Notes

The service runs as a systemd user service (`systemctl --user start ollama`) and listens on the default `127.0.0.1:11434`. `loadModels` ensures `qwen2.5vl:7b` is pulled on first activation.