### PR TITLE
fix(ollama): replace loadModels with oneshot pull service

### DIFF
--- a/modules/home-manager/ollama/default.nix
+++ b/modules/home-manager/ollama/default.nix
@@ -1,8 +1,20 @@
-{...}: {
+{pkgs, ...}: {
   services.ollama = {
     enable = true;
-    loadModels = [
-      "qwen2.5vl:7b"
-    ];
+  };
+
+  # Pull the vision model that pi-vision-handoff is configured to use.
+  systemd.user.services.ollama-pull-qwen2_5vl = {
+    Unit = {
+      Description = "Pull qwen2.5vl:7b vision model for ollama";
+      After = ["ollama.service"];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.ollama}/bin/ollama pull qwen2.5vl:7b";
+    };
+    Install = {
+      WantedBy = ["default.target"];
+    };
   };
 }


### PR DESCRIPTION
## Summary

Fixes the `services.ollama.loadModels` option used in #201, which does not exist in home-manager. home-manager's `services.ollama` only exposes `enable`, `package`, `host`, `port`, `acceleration`, and `environmentVariables`.

## Changes

Replaces the non-existent `loadModels` with a `systemd.user.services.ollama-pull-qwen2_5vl` oneshot that runs `ollama pull qwen2.5vl:7b` after the `ollama.service` starts, so the vision model is preloaded on activation.

## Verification

- `nix flake check` passes.
- `home-manager switch` now succeeds (previously failed with `The option services.ollama.loadModels does not exist`).