### PR TITLE
fix(ollama): wait for server readiness before pulling model

### DIFF
--- a/modules/home-manager/ollama/default.nix
+++ b/modules/home-manager/ollama/default.nix
@@ -8,9 +8,12 @@
     Unit = {
       Description = "Pull qwen2.5vl:7b vision model for ollama";
       After = ["ollama.service"];
+      Requires = ["ollama.service"];
     };
     Service = {
       Type = "oneshot";
+      # Wait for the ollama server to accept connections before pulling.
+      ExecStartPre = "${pkgs.bash}/bin/bash -c 'for i in $(seq 1 30); do ${pkgs.curl}/bin/curl -sf http://127.0.0.1:11434/ >/dev/null && exit 0; sleep 1; done; exit 1'";
       ExecStart = "${pkgs.ollama}/bin/ollama pull qwen2.5vl:7b";
     };
     Install = {


### PR DESCRIPTION
## Summary

The `ollama-pull-qwen2_5vl` oneshot from #202 fails on `home-manager switch` because `After=` only orders unit startup — it does not wait for the ollama server to actually accept connections. The pull runs immediately after `ollama.service` starts and hits `could not connect to ollama server`.

## Changes

Add `ExecStartPre` that polls `http://127.0.0.1:11434/` once per second for up to 30 seconds, exiting 0 only once the server responds. Also add `Requires=ollama.service` so the pull is coupled to the server unit. The model pull (`ExecStart`) now runs only after the server is confirmed ready.

## Verification

`nix flake check` passes. After merge, `home-manager switch` starts both units and the pull succeeds without manual intervention.