### PR TITLE
feat(claude): add install-code-review-graph app

### DIFF
--- a/apps/default.nix
+++ b/apps/default.nix
@@ -22,6 +22,15 @@
     '';
   };
 
+  installCodeReviewGraph = pkgs.writeShellApplication {
+    name = "install-code-review-graph";
+    runtimeInputs = with pkgs; [uv];
+    text = ''
+      uv tool install code-review-graph
+      claude mcp add --scope project code-review-graph -- uvx code-review-graph serve
+    '';
+  };
+
   claudeStatusline = pkgs.writeShellApplication {
     name = "claude-statusline";
     runtimeInputs = with pkgs; [jq];
@@ -163,6 +172,10 @@ in {
   install-claude-plugins = {
     type = "app";
     program = "${installClaudePlugins}/bin/install-claude-plugins";
+  };
+  install-code-review-graph = {
+    type = "app";
+    program = "${installCodeReviewGraph}/bin/install-code-review-graph";
   };
   claude-statusline = {
     type = "app";


### PR DESCRIPTION
## Why

The code-review-graph MCP server was installed manually on this machine (`uv tool install` + `.mcp.json` in the target repo). This makes the setup reproducible from dotfiles, following the same pattern as `install-claude-plugins`.

## Usage

```sh
# run inside the target repository
nix run .#install-code-review-graph
```

Installs the `code-review-graph` CLI via `uv tool install` and registers it as a project-scope stdio MCP server (`.mcp.json`) for Claude Code.